### PR TITLE
[feat] 表单传入数据 增加 text字段 用来表示表单中的文本信息，与value字段进行区分

### DIFF
--- a/example/components/Example/Radio.vue
+++ b/example/components/Example/Radio.vue
@@ -5,8 +5,6 @@
         <span class="iconfont icon-zuosanjiao"></span>
       </router-link>
     </wd-header>
-    <br>
-    <br>
     <div>
       <p class="radio-header">RadioGroup组件</p>
      <wd-radiogroup :listData="lists" :name="'group1'" v-model="value1"></wd-radiogroup>
@@ -35,7 +33,7 @@
               :text="list.value"
               v-model="value4"
               ></wd-radio>
-              <p class="custome-text">{{list.value || list}}</p>
+              <p class="custome-text">{{list.text || list.value || list}}</p>
           </label>
         </li>
       </ul>
@@ -50,9 +48,9 @@ export default {
   data() {
     return {
       lists: ['选项1', '选项2', '选项3', '选项4'],
-      lists2: [{value: '选项1'}, {value: '选中'}, {value: '选项3'}, {value: '被禁用', disChoose: true}],
-      lists3: [{value: '选项1'}, {value: '选项2'}, {value: '被禁用', disChoose: true}, {value: '选中禁用', disChoose: true}],
-      lists4: [{value: '选项1'}, {value: '选项2'}, {value: '选项3'}, {value: '选项4'}],
+      lists2: [{value: '选项1', text: '选项text1'}, {value: '选中', text: '选中text'}, {value: '选项3', text: '选项text3'}, {value: '被禁用', text: '被禁用text', disChoose: true}],
+      lists3: [{value: '选项1', text: '选项text1'}, {value: '选项2', text: '选项text2'}, {value: '被禁用', text: '被禁用text', disChoose: true}, {value: '选中禁用', disChoose: true, text: '选中禁用text2'}],
+      lists4: [{value: '选项1', text: '选项text1'}, {value: '选项2', text: '选项text2'}, {value: '选项3', text: '选项text3'}, {value: '选项4', text: '选项text4'}],
       value1: '选项2',
       value2: '选中',
       value3: '选中禁用',

--- a/packages/RadioGroup/src/RadioGroup.vue
+++ b/packages/RadioGroup/src/RadioGroup.vue
@@ -11,7 +11,7 @@
         :text="list.value || list"
         v-model="currentValue"
         ></wd-radio>
-        <p class="wd-radiogroup-text">{{list.value || list}}</p>
+        <p class="wd-radiogroup-text">{{list.text || list.value || list}}</p>
       </label>
     </li>
    </ul>

--- a/test/unit/RadioGroup.spec.js
+++ b/test/unit/RadioGroup.spec.js
@@ -29,6 +29,32 @@ describe('RadioGroup', () => {
       done()
     })
   })
+  it('RadioGroup 初始化对象数据', done => {
+    vm = createVueInstance({
+      template: `
+        <wd-radiogroup :listData="lists" :name="'group1'" v-model="value1"></wd-radiogroup>
+      `,
+      data() {
+        return {
+          lists: [{value: '选项1', text: '选项text1'}, {value: '选项2', text: '选项text2'}, {value: '选项3', text: '选项text3'}, {value: '选项4', text: '选项text4'}],
+          value1: ''
+        }
+      }
+    })
+    Vue.nextTick(() => {
+      const $dom = document.body.querySelector('.wd-radiogroup')
+      expect($dom).to.exist
+      const inputNum = $dom.getElementsByTagName('input').length
+      expect(inputNum).to.equal(vm.lists.length)
+      const listsText = document.body.querySelectorAll('.wd-radiogroup-text')
+      expect(listsText[0].innerText).to.equal('选项text1')
+      expect(listsText[1].innerText).to.equal('选项text2')
+      expect(listsText[2].innerText).to.equal('选项text3')
+      expect(listsText[3].innerText).to.equal('选项text4')
+      destroyVM(vm)
+      done()
+    })
+  })
   it('RadioGroup 选中值', done => {
     vm = createVueInstance({
       template: `
@@ -107,6 +133,7 @@ describe('RadioGroup', () => {
       done()
     })
   })
+
   it('RadioGroup 切换禁用选中', done => {
     vm = createVueInstance({
       template: `


### PR DESCRIPTION
表单传入数据 增加 text字段 用来表示表单中的文本信息，与value字段进行区分；

传入数据listData 如下：
`listData: [{value: '选项1', text: '选项text1'}, {value: '选中', text: '选中text'}, {value: '选项3', text: '选项text3'}, {value: '被禁用', text: '被禁用text', disChoose: true}]`